### PR TITLE
Feature/color

### DIFF
--- a/src/components/CTable/index.meta.js
+++ b/src/components/CTable/index.meta.js
@@ -7,12 +7,7 @@ export default {
     { name: 'DataSourceChanged' },
   ],
   options: {
-    color: {
-      type: 'input',
-      name: 'Color',
-      value: null,
-      priority: 1,
-    },
+    color: true,
     flat: {
       type: 'check',
       name: 'No Shadow',


### PR DESCRIPTION
This PR sets color as boolean which will Builder read and set option as `colorPicker`.
Currently we support two simple bool properties: `theme` and `color` that simplifies meta for bundles.