### PR TITLE
Add landingPage option and extend parent definition #39

### DIFF
--- a/src/components/CPage/index.meta.js
+++ b/src/components/CPage/index.meta.js
@@ -42,14 +42,19 @@ export default {
       name: 'Path',
       value: '/',
       priority: 2,
+      validation: {
+        required: true,
+      },
     },
     parent: {
       type: 'select',
       name: 'Parent',
       value: null,
       displayProp: 'name',
+      clearable: true,
       valueProp: 'name',
       items: '=$app.pages',
+      filterItemsOut: '=$activePage.name',
       priority: 3,
     },
     icon: {
@@ -57,6 +62,12 @@ export default {
       name: 'Icon',
       value: null,
       priority: 4,
+    },
+    landingPage: {
+      type: 'check',
+      name: 'Set as landing page',
+      value: false,
+      priority: 5,
     },
     layout: {
       type: 'group',


### PR DESCRIPTION
- `path` option is set to required
- `parent` option extended with `clearable` prop 
- `parent` option items filtering can be defined with `filterItemsOut` prop - both primitive and complex items can be filtered. If items are array of objects, they can be filtered with `filterItemsOutByProp` which will be applied to item. If not provided, `valueProp` will be used. If none of these are provided, items will be treated as array of primitives (implemented in [106](https://github.com/chmjs/chameleon-builder/pull/106)).