### PR TITLE
Set components key properly #84

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "material",
   "namespace": "c-",
-  "version": 51,
+  "version": 53,
   "styles": [
     "bundle.min.css"
   ],

--- a/src/components/CAccordionItem/CAccordionItem.js
+++ b/src/components/CAccordionItem/CAccordionItem.js
@@ -50,7 +50,7 @@ const getListeners = (context) => {
 export default {
   extends: Element,
   render(createElement) {
-    const props = {
+    const data = {
       key: this.schema.uid,
       props: this.config,
       on: getListeners(this),
@@ -64,7 +64,7 @@ export default {
 
     return this.renderElement(
       'v-expansion-panel-content',
-      props,
+      data,
       children,
       true,
     );

--- a/src/components/CFlexgrid/CFlexgrid.js
+++ b/src/components/CFlexgrid/CFlexgrid.js
@@ -1,5 +1,4 @@
 import { map } from 'lodash';
-import { v4 } from 'uuid';
 import Element from '../Element';
 
 const getContainerAttrs = (context) => {
@@ -24,7 +23,6 @@ const getLayoutAttrs = (context) => {
   return attrs;
 };
 
-const uuid = () => v4();
 
 export default {
   extends: Element,
@@ -32,7 +30,6 @@ export default {
     const items = map(this.config.elements, element => createElement(
       this.getElementTag('flexgrid-item'),
       {
-        key: `${element.type}_${uuid()}`,
         props: {
           definition: element,
         },
@@ -40,6 +37,7 @@ export default {
     ));
 
     const data = {
+      key: this.schema.uid,
       class: getContainerAttrs(this),
       props: {
         dark: this.isThemeDark,

--- a/src/components/CFlexgridItem/CFlexgridItem.js
+++ b/src/components/CFlexgridItem/CFlexgridItem.js
@@ -4,6 +4,7 @@ export default {
   extends: Element,
   render() {
     const data = {
+      key: this.schema.uid,
       class: {
         [`xs${this.config.width}`]: true,
         [this.config.color]: true,

--- a/src/components/CGallery/CGallery.js
+++ b/src/components/CGallery/CGallery.js
@@ -79,10 +79,10 @@ const getGalleryElement = (createElement, context, imageSource) => {
           'v-carousel-item',
           {
             attrs: {
-              key: i,
               src: getUrlValidator(item) ?
                 getCarouselSource(item) : parseImageSrc(context, item),
             },
+            key: i,
           },
         )),
         getCloseBtnOverlay(createElement, self),
@@ -94,9 +94,7 @@ const getGalleryElement = (createElement, context, imageSource) => {
       attrs: {
         [`xs${context.config.gallery.gridSize}`]: true,
       },
-      props: {
-        key: i,
-      },
+      key: i,
     },
     [
       createElement('v-card', {

--- a/src/components/CHlist/CHlist.js
+++ b/src/components/CHlist/CHlist.js
@@ -5,20 +5,19 @@ require('../../style/components/_hlist.styl');
 export default {
   extends: Element,
   render() {
-    const self = this;
     const data = {
-      key: self.schema.uid,
+      key: this.schema.uid,
       class: {
-        [`${self.$options.name}--spaced`]: self.config.gutter,
+        [`${this.$options.name}--spaced`]: this.config.gutter,
       },
       props: {
-        color: self.config.color,
-        dark: self.isThemeDark,
-        light: self.isThemeLight,
-        flat: self.config.flat,
+        color: this.config.color,
+        dark: this.isThemeDark,
+        light: this.isThemeLight,
+        flat: this.config.flat,
       },
       style: {
-        height: self.config.height,
+        height: this.config.height,
       },
     };
     const style = {

--- a/src/components/CTabItem/CTabItem.js
+++ b/src/components/CTabItem/CTabItem.js
@@ -21,8 +21,8 @@ export default {
   extends: Element,
   render(createElement) {
     const data = {
+      key: this.schema.uid,
       props: {
-        key: this.schema.uid,
         id: String(this.schema.uid),
       },
     };

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -53,8 +53,7 @@ const getCellInferredProps = (cell) => {
 };
 
 const getScopedSlots = (createElement, context) => {
-  const self = context;
-  const dataSource = self.dataSource;
+  const dataSource = context.dataSource;
   const getColumns = (props) => {
     const item = props.item;
     const columns = [];

--- a/src/components/CTabs/CTabs.js
+++ b/src/components/CTabs/CTabs.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { v4 } from 'uuid';
 import Element from '../Element';
 
 const getProps = (context) => {
@@ -15,7 +14,6 @@ const getProps = (context) => {
   return props;
 };
 
-const uuid = () => v4();
 
 const getTabs = (context, createElement) => {
   const config = context.config;
@@ -34,7 +32,7 @@ const getTabs = (context, createElement) => {
     return createElement(
       'v-tab',
       {
-        key: `tab${i}_${uuid}`,
+        key: `tab${i}_${context.schema.uid}`,
       },
       children,
     );


### PR DESCRIPTION
- Set key from `schema.uid` instead of generating new uuid
- Fixed key assignment on Gallery and TabItem - key is top-level prop, not part of attrs or props