### PR TITLE
Bugfix/double source load

### DIFF
--- a/dev/data/page.json
+++ b/dev/data/page.json
@@ -641,16 +641,20 @@
                       "dataSource": {
                         "schema": [
                           {
-                            "name": "value",
-                            "type": "String"
-                          },
-                          {
-                            "name": "name",
+                            "name": "title",
                             "type": "String"
                           },
                           {
                             "name": "description",
                             "type": "String"
+                          },
+                          {
+                            "name": "thumb",
+                            "type": "image"
+                          },
+                          {
+                            "name": "icon",
+                            "type": "icon"
                           }
                         ],
                         "items": [

--- a/dev/data/table.json
+++ b/dev/data/table.json
@@ -12,7 +12,6 @@
             {
               "name": "shoppingTable",
               "type": "table",
-              "theme": "dark",
               "rowsPerPage": 10,
               "dataSource": {
                 "name": "temperaturesPerCity",

--- a/src/components/CCheckList/CCheckList.js
+++ b/src/components/CCheckList/CCheckList.js
@@ -94,9 +94,6 @@ export default {
       });
     },
   },
-  mounted() {
-    this.loadData();
-  },
   render(createElement) {
     const message = createErrorMessage(createElement, this);
 

--- a/src/components/CGallery/CGallery.js
+++ b/src/components/CGallery/CGallery.js
@@ -163,9 +163,6 @@ export default {
       deep: true,
     },
   },
-  mounted() {
-    this.loadData();
-  },
   methods: {
     loadData() {
       this.loadConnectorData().then((result) => {

--- a/src/components/CList/CList.js
+++ b/src/components/CList/CList.js
@@ -185,7 +185,6 @@ export default {
   },
   mounted() {
     this.pagination = getPagination(this.config);
-    this.loadData();
   },
   render(createElement) {
     const list = createElement('v-data-iterator', {

--- a/src/components/CMenu/CMenu.js
+++ b/src/components/CMenu/CMenu.js
@@ -186,9 +186,6 @@ export default {
       this.setItemsOrLoad();
     },
   },
-  mounted() {
-    this.setItemsOrLoad();
-  },
   render(createElement) {
     return this.renderElement(
       'v-navigation-drawer',

--- a/src/components/CMenu/CMenu.js
+++ b/src/components/CMenu/CMenu.js
@@ -46,17 +46,13 @@ export default {
     selectItem(item) {
       this.sendToEventBus('SelectedItemChanged', item);
     },
-    setItemsOrLoad() {
-      if (this.config.autoGenerate) {
-        const pages = this.getBindingValue('=$app.pages');
-        this.items = map(pages, page => ({
-          icon: page.icon,
-          label: page.meta.title,
-          path: page.path,
-        }));
-      } else {
-        this.loadData();
-      }
+    setItems() {
+      const pages = this.getBindingValue('=$app.pages');
+      this.items = map(pages, page => ({
+        icon: page.icon,
+        label: page.meta.title,
+        path: page.path,
+      }));
     },
     renderDivider() {
       return this.$createElement(
@@ -182,8 +178,8 @@ export default {
         this.loadData();
       }
     },
-    autoGenerate() {
-      this.setItemsOrLoad();
+    autoGenerate(val) {
+      if (val) this.setItems();
     },
   },
   render(createElement) {

--- a/src/components/CRadioList/CRadioList.js
+++ b/src/components/CRadioList/CRadioList.js
@@ -82,9 +82,6 @@ export default {
       });
     },
   },
-  mounted() {
-    this.loadData();
-  },
   render(createElement) {
     if (isNil(this.config.dataSource)) {
       this.config.dataSource = {

--- a/src/components/CSelect/CSelect.js
+++ b/src/components/CSelect/CSelect.js
@@ -112,7 +112,6 @@ export default {
   created() {
     this.selectAttr = getAttrs(this);
     this.selectListeners = getListeners(this);
-    this.loadData();
   },
   render(createElement) {
     const children = createElement(

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -232,7 +232,6 @@ export default {
   },
   mounted() {
     this.pagination = getPagination(this.config);
-    this.loadData();
   },
   render(createElement) {
     const table = createElement('v-data-table', {


### PR DESCRIPTION
- Removed data load on mounted hook from all sourceable elements
- Changed autoGenerate watcher on menu, it only sets items, without data loading (dataSource watcher gets triggered anyway, so it loads data if autoGenerate isn't active)

Resolves #87 