### PR TITLE
Feature/sizeInput

### DIFF
--- a/src/components/CGallery/index.meta.js
+++ b/src/components/CGallery/index.meta.js
@@ -102,7 +102,7 @@ export default {
       type: 'group',
       group: 'gallery',
       itemHeight: {
-        type: 'input',
+        type: 'sizeInput',
         name: 'Item Height',
         value: '100px',
       },

--- a/src/components/CHlist/index.meta.js
+++ b/src/components/CHlist/index.meta.js
@@ -106,7 +106,7 @@ export default {
       priority: 3,
     },
     height: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Height',
       value: null,
       priority: 4,

--- a/src/components/CImage/index.meta.js
+++ b/src/components/CImage/index.meta.js
@@ -29,13 +29,13 @@ export default {
       priority: 2,
     },
     width: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Width',
       value: null,
       priority: 3,
     },
     height: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Height',
       value: null,
       priority: 4,

--- a/src/components/CMenu/index.meta.js
+++ b/src/components/CMenu/index.meta.js
@@ -61,13 +61,13 @@ export default {
       priority: 7,
     },
     height: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Height',
       value: null,
       priority: 8,
     },
     width: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Width',
       value: null,
       priority: 9,

--- a/src/components/CPage/index.meta.js
+++ b/src/components/CPage/index.meta.js
@@ -80,12 +80,12 @@ export default {
         value: false,
       },
       previewWidth: {
-        type: 'input',
+        type: 'sizeInput',
         name: 'Preview Width',
         value: '960px',
       },
       previewHeight: {
-        type: 'input',
+        type: 'sizeInput',
         name: 'Preview Height',
         value: '1360px',
       },

--- a/src/components/CPanel/index.meta.js
+++ b/src/components/CPanel/index.meta.js
@@ -27,20 +27,6 @@ export default {
       name: 'Height',
       value: null,
       priority: 4,
-      units: [
-        {
-          value: 'px',
-          name: 'px',
-        },
-        {
-          value: '%',
-          name: '%',
-        },
-        {
-          value: 'eee',
-          name: 'eee',
-        },
-      ],
     },
     theme: true,
   },

--- a/src/components/CPanel/index.meta.js
+++ b/src/components/CPanel/index.meta.js
@@ -17,16 +17,30 @@ export default {
       priority: 2,
     },
     width: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Width',
       value: null,
       priority: 3,
     },
     height: {
-      type: 'input',
+      type: 'sizeInput',
       name: 'Height',
       value: null,
       priority: 4,
+      units: [
+        {
+          value: 'px',
+          name: 'px',
+        },
+        {
+          value: '%',
+          name: '%',
+        },
+        {
+          value: 'eee',
+          name: 'eee',
+        },
+      ],
     },
     theme: true,
   },


### PR DESCRIPTION
Changed `input` type in meta to `sizeInput` where I found it to be relevant. It's backward compatible, and previously entered sizing values (if using valid units) should be applied to new type.

I already changed `CPanel` for test purposes befowe, sowwy.