### PR TITLE
Feature/table sort

### DIFF
--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -181,7 +181,7 @@ const getListeners = (context) => {
 
   return {
     'update:pagination': (value) => {
-      if (self.pagination) {
+      if (self.pagination && self.totalItems) {
         self.pagination = getClientPagination(self.config, value);
         self.loadData();
         self.sendToEventBus('PaginationChanged', value);
@@ -195,7 +195,7 @@ export default {
   data() {
     return {
       items: [],
-      pagination: {},
+      pagination: null,
       totalItems: null,
     };
   },

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -181,7 +181,7 @@ const getListeners = (context) => {
 
   return {
     'update:pagination': (value) => {
-      if (self.pagination && self.totalItems) {
+      if (self.pagination && self.dataLoaded) {
         self.pagination = getClientPagination(self.config, value);
         self.loadData();
         self.sendToEventBus('PaginationChanged', value);
@@ -197,6 +197,7 @@ export default {
       items: [],
       pagination: null,
       totalItems: null,
+      dataLoaded: false,
     };
   },
   methods: {
@@ -206,6 +207,7 @@ export default {
       this.loadConnectorData().then((result) => {
         this.items = result.items || [];
         this.totalItems = result.pagination ? result.pagination.totalResults : 0;
+        this.dataLoaded = true;
         this.sendToEventBus('DataSourceChanged', this.dataSource);
       });
     },

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -170,7 +170,7 @@ const setDataSourceParams = (context) => {
 
   self.dataSourceParams = merge(self.dataSourceParams, {
     pageSize: self.pagination.rowsPerPage,
-    sort: self.config.sort,
+    sort: self.pagination.descending ? 'desc' : 'asc',
     sortBy: self.pagination.sortBy,
     currentPage: self.pagination.page,
   });

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -3,7 +3,7 @@ import Element from '../Element';
 import '../../style/components/_table.styl';
 
 const getPropRowsPerPageItems = (value) => {
-  if (isNil(value)) {
+  if (!value) {
     return [5, 10, 15, 20];
   } else if (isString(value)) {
     if (value.indexOf(',') > -1) {
@@ -127,7 +127,7 @@ const getHeadersProp = (dataSource) => {
 const getClientPagination = (config, setPagination) => defaults(setPagination || {}, {
   rowsPerPage: config.rowsPerPage,
   sortBy: config.sortBy,
-  descending: config.sort === 'desc',
+  descending: config.sort ? config.sort === 'desc' : null,
   page: config.startPage,
 });
 
@@ -181,9 +181,13 @@ const getListeners = (context) => {
 
   return {
     'update:pagination': (value) => {
-      self.pagination = getClientPagination(self.config, value);
-      self.loadData();
-      self.sendToEventBus('PaginationChanged', value);
+      console.log('DSP', JSON.stringify(self.dataSourceParams), JSON.stringify(self.pagination));
+
+      if (self.pagination) {
+        self.pagination = getClientPagination(self.config, value);
+        self.loadData();
+        self.sendToEventBus('PaginationChanged', value);
+      }
     },
   };
 };
@@ -200,6 +204,8 @@ export default {
   methods: {
     loadData() {
       setDataSourceParams(this);
+
+      console.log(this.dataSourceParams);
 
       this.loadConnectorData().then((result) => {
         this.items = result.items || [];
@@ -223,6 +229,10 @@ export default {
       },
       deep: true,
     },
+  },
+  mounted() {
+    this.pagination = getClientPagination(this.config);
+    this.loadData();
   },
   render(createElement) {
     const table = createElement('v-data-table', {

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -181,8 +181,6 @@ const getListeners = (context) => {
 
   return {
     'update:pagination': (value) => {
-      console.log('DSP', JSON.stringify(self.dataSourceParams), JSON.stringify(self.pagination));
-
       if (self.pagination) {
         self.pagination = getClientPagination(self.config, value);
         self.loadData();
@@ -204,8 +202,6 @@ export default {
   methods: {
     loadData() {
       setDataSourceParams(this);
-
-      console.log(this.dataSourceParams);
 
       this.loadConnectorData().then((result) => {
         this.items = result.items || [];

--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -79,14 +79,13 @@ const getScopedSlots = (createElement, context) => {
                   // NOTE: Expose in options?
                   size: '32px',
                 },
-              },
-                [
-                  createElement('img', {
-                    attrs: {
-                      src: content,
-                    },
-                  }),
-                ]),
+              }, [
+                createElement('img', {
+                  attrs: {
+                    src: content,
+                  },
+                }),
+              ]),
             ];
             break;
           default:
@@ -125,24 +124,12 @@ const getHeadersProp = (dataSource) => {
   }, getCellInferredProps(column))));
 };
 
-const getPagination = (config) => {
-  const defaultPagination = {
-    descending: false,
-    sortBy: null,
-    rowsPerPage: 10,
-    page: 1,
-    totalItems: 0,
-  };
-
-  const pagination = defaults({
-    rowsPerPage: config.rowsPerPage,
-    sortBy: config.sortBy,
-    descending: config.sortDescending,
-    page: config.startPage,
-  }, defaultPagination);
-
-  return pagination;
-};
+const getClientPagination = (config, setPagination) => defaults(setPagination || {}, {
+  rowsPerPage: config.rowsPerPage,
+  sortBy: config.sortBy,
+  descending: config.sort === 'desc',
+  page: config.startPage,
+});
 
 const getProps = (context) => {
   const config = context.config;
@@ -158,6 +145,7 @@ const getProps = (context) => {
     headers: columns ? getHeadersProp(dataSource) : [],
     itemKey: columns ? keys(columns[0])[0] : 'id',
     loading: context.loadingDataSource,
+    mustSort: false,
     rowsPerPageItems: getPropRowsPerPageItems(config.rowsPerPageItems),
   };
 
@@ -174,26 +162,30 @@ const getProps = (context) => {
   return props;
 };
 
+const setDataSourceParams = (context) => {
+  const self = context;
+
+  // Remove params set in SDK
+  delete self.dataSourceParams.pagination;
+
+  self.dataSourceParams = merge(self.dataSourceParams, {
+    pageSize: self.pagination.rowsPerPage,
+    sort: self.config.sort,
+    sortBy: self.pagination.sortBy,
+    currentPage: self.pagination.page,
+  });
+};
+
 const getListeners = (context) => {
   const self = context;
 
-  const listeners = {
+  return {
     'update:pagination': (value) => {
-      /*
-      Weird solution but since we are changing paging this
-      gets triggered a lot of times since we do not have
-      sync modifier.
-      */
-      if (self.pagination && self.pagination.totalItems && self.dataSourceParams.pagination) {
-        self.dataSourceParams.pagination.page = value.page;
-        self.loadData();
-      }
+      self.pagination = getClientPagination(self.config, value);
+      self.loadData();
       self.sendToEventBus('PaginationChanged', value);
-      self.pagination = value;
     },
   };
-
-  return listeners;
 };
 
 export default {
@@ -201,12 +193,14 @@ export default {
   data() {
     return {
       items: [],
-      pagination: null,
+      pagination: {},
       totalItems: null,
     };
   },
   methods: {
     loadData() {
+      setDataSourceParams(this);
+
       this.loadConnectorData().then((result) => {
         this.items = result.items || [];
         this.totalItems = result.pagination ? result.pagination.totalResults : 0;
@@ -229,9 +223,6 @@ export default {
       },
       deep: true,
     },
-  },
-  mounted() {
-    this.pagination = getPagination(this.config);
   },
   render(createElement) {
     const table = createElement('v-data-table', {

--- a/src/components/CTable/index.meta.js
+++ b/src/components/CTable/index.meta.js
@@ -112,14 +112,6 @@ export default {
       value: null,
       priority: 11,
     },
-    sortDisabled: {
-      flat: {
-        type: 'check',
-        name: 'No Shadow',
-        value: false,
-        priority: 2,
-      },
-    },
     theme: true,
   },
 };

--- a/src/components/CTable/index.meta.js
+++ b/src/components/CTable/index.meta.js
@@ -91,16 +91,34 @@ export default {
     sortBy: {
       type: 'input',
       group: 'data',
-      name: 'Sort Items By',
+      name: 'Default Sorting By',
       value: null,
       priority: 10,
     },
-    sortDescending: {
-      type: 'check',
+    sort: {
+      type: 'select',
       group: 'data',
-      name: 'Sort Descending',
-      value: false,
+      name: 'Default Sorting',
+      items: [
+        {
+          name: 'Ascending',
+          value: 'asc',
+        },
+        {
+          name: 'Descending',
+          value: 'desc',
+        },
+      ],
+      value: null,
       priority: 11,
+    },
+    sortDisabled: {
+      flat: {
+        type: 'check',
+        name: 'No Shadow',
+        value: false,
+        priority: 2,
+      },
     },
     theme: true,
   },


### PR DESCRIPTION
Remote source data fetch should work now. Implemented server-side pagination/sorting stuff.

Related to chmjs/chameleon-api#60.

Changed `sort` config option to be a select, so that user can explicitely choose the relevant option, without us assuming that he wants or doesn't want _descending_.