### PR TITLE
Support alterneting rows  fixes #120

### DIFF
--- a/src/components/CTable/CTable.js
+++ b/src/components/CTable/CTable.js
@@ -52,6 +52,26 @@ const getCellInferredProps = (cell) => {
   };
 };
 
+const getAlternatingRowColor = (rowParity, context) => {
+  const colorClass = context.config.color ? context.config.color.split(' ') : [];
+  const colorName = colorClass.length ? colorClass[0] : 'grey';
+  let alternatingRowColor = context.config.alternetingRowColor || `${colorName} darken-2`;
+
+  // use darken and lighten classes if alternetingRowColor is not set
+  if (colorClass.length > 1 && !context.config.alternetingRowColor) {
+    const colorWeight = colorClass[1].split('-')[0] === 'darken' ? 'lighten-3' : 'darken-3';
+    alternatingRowColor = `${colorName} ${colorWeight}`;
+  }
+
+  return rowParity % 2 === 0 ? alternatingRowColor : `${context.config.color}`;
+};
+
+const setRowColor = (rowIndex, context) => {
+  const isAlternetingRowOption = context.config.alternetingRows;
+  // eslint-disable-next-line
+  return isAlternetingRowOption ? getAlternatingRowColor(rowIndex, context) : null;
+};
+
 const getScopedSlots = (createElement, context) => {
   const dataSource = context.dataSource;
   const getColumns = (props) => {
@@ -101,8 +121,10 @@ const getScopedSlots = (createElement, context) => {
     return columns;
   };
 
+
   const slot = {
     items: props => createElement('tr', {
+      staticClass: setRowColor(props.index, context),
       on: {
         click() {
           const item = props.item;
@@ -115,11 +137,12 @@ const getScopedSlots = (createElement, context) => {
   return slot;
 };
 
-const getHeadersProp = (dataSource) => {
+const getHeadersProp = (dataSource, config) => {
   const columns = dataSource.schema;
 
   return map(columns, column => (merge({
     value: column.name,
+    class: config.headerColor || config.color,
     text: column.title || column.name,
   }, getCellInferredProps(column))));
 };
@@ -142,7 +165,7 @@ const getProps = (context) => {
     light: context.isThemeLight,
     items: context.items,
     hideHeaders: !columns,
-    headers: columns ? getHeadersProp(dataSource) : [],
+    headers: columns ? getHeadersProp(dataSource, config) : [],
     itemKey: columns ? keys(columns[0])[0] : 'id',
     loading: context.loadingDataSource,
     mustSort: false,

--- a/src/components/CTable/index.meta.js
+++ b/src/components/CTable/index.meta.js
@@ -32,26 +32,25 @@ export default {
     },
   ],
   options: {
-    color: true,
     flat: {
       type: 'check',
       name: 'No Shadow',
       value: false,
-      priority: 2,
+      priority: 1,
     },
     noDataText: {
       type: 'input',
       group: 'localization',
       name: 'No Data Text',
       value: null,
-      priority: 3,
+      priority: 2,
     },
     noResultsText: {
       type: 'input',
       group: 'localization',
       name: 'No Results Text',
       value: null,
-      priority: 4,
+      priority: 3,
     },
     rowsPerPageText: {
       type: 'input',
@@ -112,6 +111,32 @@ export default {
       value: null,
       priority: 11,
     },
-    theme: true,
+    theme: {
+      group: 'style',
+      priority: 12,
+    },
+    color: {
+      group: 'style',
+      priority: 13,
+    },
+    alternetingRows: {
+      group: 'style',
+      type: 'check',
+      name: 'Enable alterneting rows',
+      value: false,
+      priority: 14,
+    },
+    alternetingRowColor: {
+      group: 'style',
+      type: 'colorPicker',
+      name: 'Alterneting row color',
+      priority: 15,
+    },
+    headerColor: {
+      group: 'style',
+      type: 'colorPicker',
+      name: 'Header color',
+      priority: 16,
+    },
   },
 };

--- a/src/index.meta.js
+++ b/src/index.meta.js
@@ -37,6 +37,10 @@ const optionGroups = {
     key: 'data',
     name: 'Data',
   },
+  style: {
+    key: 'style',
+    name: 'Style',
+  },
 };
 
 export default {


### PR DESCRIPTION
Alternating rows option is added on CTable component. Option to activate and change alternetingRow color is added, also option for changing header color is supported. I saw desing for NB results on zeplin we should also add option for hiding actions container and support pagination. I'll make different issue for that and support also changing footer color there.