### PR TITLE
Support MPEG-1 streams #163

### DIFF
--- a/dev/data/page.json
+++ b/dev/data/page.json
@@ -956,9 +956,23 @@
                         {
                           "type": "video-stream",
                           "name": "video stream widget",
-                          "streamType": "img",
-                          "value": "http://admin:SyncShop17@172.20.50.245/Streaming/channels/102/httppreview",
-                          "aspectRatio": "auto"
+                          "streamType": "jsmpeg",
+                          "value": null,
+                          "valueMask": "wss://vision.nsoft.com/streaming/${_id}?type=high",
+                          "aspectRatio": "auto",
+                          "dataSource": {
+                            "local": true,
+                            "items": [
+                              {
+                                "thumb": "5c48351c604d2872fad4cb2c",
+                                "enabled": true,
+                                "address": "rtsp://admin:SyncShop17@172.20.50.243:554/Streaming/Channels/101",
+                                "process_camera": true,
+                                "_id": "5c3e2853c1f89736c4a5742d",
+                                "name": "Pano"
+                              }
+                            ]
+                          }
                         }
                       ]
                     }

--- a/src/components/CVideoStream/CVideoStream.js
+++ b/src/components/CVideoStream/CVideoStream.js
@@ -1,4 +1,4 @@
-import { isNil, isObject, template, upperFirst } from 'lodash';
+import { isNil, isFunction, isObject, template, upperFirst } from 'lodash';
 import Element from '../Element';
 
 export default {
@@ -55,7 +55,6 @@ export default {
       let type = isNil(this.config.streamType) ? 'image' : this.config.streamType;
 
       if (type === 'img') type = 'image';
-      if (type === 'mpeg') type = 'jsmpeg';
 
       return upperFirst(type);
     },
@@ -129,5 +128,10 @@ export default {
     return this.renderElement('div', {
       staticStyle: this.staticStyle,
     }, children);
+  },
+  beforeDestroy() {
+    if (this.player && isFunction(this.player.destroy)) {
+      this.player.destroy();
+    }
   },
 };

--- a/src/components/CVideoStream/CVideoStream.js
+++ b/src/components/CVideoStream/CVideoStream.js
@@ -1,71 +1,133 @@
-import { isNil, isObject } from 'lodash';
+import { isNil, isObject, template, upperFirst } from 'lodash';
 import Element from '../Element';
-
-const getStreamType = (config) => {
-  const type = isNil(config.streamType) ? 'img' : config.streamType;
-  return type;
-};
-
-const getStaticStyle = (config) => {
-  let height = 'auto';
-  let paddingTop = 0;
-
-  if (config.aspectRatio !== 'auto' && !isNil(config.aspectRatio)) {
-    height = 0;
-    const ratioValue = config.aspectRatio.split(':');
-    paddingTop = `${(ratioValue[1] / ratioValue[0]) * 100}%`;
-  }
-
-  const style = {
-    position: 'relative',
-    overflow: 'hidden',
-    width: '100%',
-    height,
-    paddingTop,
-  };
-
-  return style;
-};
 
 export default {
   extends: Element,
+  data() {
+    return {
+      player: null,
+      playerHandler: null,
+    };
+  },
+  computed: {
+    dependencies() {
+      if (this.streamType === 'Jsmpeg') {
+        return {
+          files: ['https://jsmpeg.com/jsmpeg.min.js'],
+          global: 'JSMpeg',
+        };
+      }
+
+      return null;
+    },
+    staticStyle() {
+      let height = 'auto';
+      let paddingTop = 0;
+
+      if (this.config.aspectRatio !== 'auto' && !isNil(this.config.aspectRatio)) {
+        height = 0;
+        const ratioValue = this.config.aspectRatio.split(':');
+        paddingTop = `${(ratioValue[1] / ratioValue[0]) * 100}%`;
+      }
+
+      const style = {
+        position: 'relative',
+        overflow: 'hidden',
+        width: '100%',
+        height,
+        paddingTop,
+      };
+
+      return style;
+    },
+    streamValue() {
+      if (this.items && this.items.length) {
+        const isMasked = !isNil(this.config.valueMask);
+        const isValueObject = isObject(this.items[0]);
+        const value = isValueObject ? this.items[0].url : this.items[0];
+
+        return isMasked && isValueObject ? template(this.config.valueMask)(this.items[0]) : value;
+      }
+
+      return this.config.value;
+    },
+    streamType() {
+      let type = isNil(this.config.streamType) ? 'image' : this.config.streamType;
+
+      if (type === 'img') type = 'image';
+      if (type === 'mpeg') type = 'jsmpeg';
+
+      return upperFirst(type);
+    },
+  },
+  methods: {
+    createPlayer() {
+      if (this.streamValue) {
+        this.player = new window[`${this.playerHandler}`].Player(this.streamValue, {
+          canvas: this.$refs.canvas,
+        });
+
+        this.player.play();
+      }
+    },
+    renderTypeImage() {
+      return this.$createElement(
+        'img',
+        {
+          attrs: {
+            src: this.streamValue || null,
+            width: '100%',
+            height: '100%',
+          },
+          staticStyle: {
+            position: this.config.aspectRatio !== 'auto' ? 'absolute' : 'relative',
+            top: 0,
+            left: 0,
+          },
+        },
+      );
+    },
+    renderTypeJsmpeg() {
+      return this.$createElement(
+        'canvas',
+        {
+          ref: 'canvas',
+          staticStyle: {
+            position: this.config.aspectRatio !== 'auto' ? 'absolute' : 'relative',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+          },
+        },
+      );
+    },
+  },
   watch: {
     dataSource: {
-      handler() {
-        this.loadData();
+      handler(current, previous) {
+        this.loadData().then(() => {
+          if (!isNil(previous) && !isNil(this.playerHandler)) {
+            this.createPlayer();
+          }
+        });
       },
       deep: true,
     },
   },
-  computed: {
-    streamValue() {
-      if (this.items && this.items.length) {
-        return isObject(this.items[0]) ? this.items[0].url : this.items[0];
-      }
-      return this.config.value;
-    },
+  mounted() {
+    if (this.dependencies) {
+      this.playerHandler = this.dependencies.global;
+      this.loadDependencies(this.dependencies.files, this.playerHandler).then(() => {
+        this.createPlayer();
+      });
+    }
   },
-  render(createElement) {
-    const data = {
-      staticStyle: getStaticStyle(this.config),
-    };
+  render() {
+    const children = this[`renderType${this.streamType}`]();
 
-    const children = createElement(
-      getStreamType(this.config),
-      {
-        attrs: {
-          src: this.streamValue || null,
-          width: '100%',
-          height: '100%',
-        },
-        staticStyle: {
-          position: this.config.aspectRatio !== 'auto' ? 'absolute' : 'relative',
-          top: 0,
-          left: 0,
-        },
-      },
-    );
-
-    return this.renderElement('div', data, children);
+    return this.renderElement('div', {
+      staticStyle: this.staticStyle,
+    }, children);
   },
 };

--- a/src/components/CVideoStream/index.meta.js
+++ b/src/components/CVideoStream/index.meta.js
@@ -44,8 +44,12 @@ export default {
       name: 'Stream Type',
       items: [
         {
-          name: 'Simple',
-          value: 'img',
+          name: 'Image',
+          value: 'image',
+        },
+        {
+          name: 'MPEG-1',
+          value: 'jsmpeg',
         },
       ],
       value: 'img',
@@ -82,6 +86,18 @@ export default {
         expression: binding.setExpression('<%= !isNil(element.dataSource) %>', expressionImport),
       },
       priority: 2,
+    },
+    valueMask: {
+      type: 'input',
+      group: 'data',
+      name: 'Stream Source Mask',
+      value: null,
+      disabled: {
+        current: false,
+        default: false,
+        expression: binding.setExpression('<%= !isNil(element.dataSource) %>', expressionImport),
+      },
+      priority: 3,
     },
     dataSource: {
       type: 'dataSource',

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -31,9 +31,11 @@ export default {
   },
   methods: {
     loadData() {
-      this.loadConnectorData().then((result) => {
+      return this.loadConnectorData().then((result) => {
         this.items = result.items || null;
         this.sendToEventBus('DataSourceChanged', this.dataSource);
+
+        return result;
       });
     },
     renderElement(tag, options, items, parentable) {


### PR DESCRIPTION
- Refactored video stream to support more types
- Moved common upper functions to methods
- Modified Element loadData methord to return Promise for further chaining
- Supported MPEG-1 stream
- Added valueMask data option so that stream url can be constructed (in long run this construction should be on Data level inside calculated field @Lanchi @moahmo take a note)

@moivica Test after review and bundle publish.
@Sneki You can publish after review.

Fix #163 