### PR TITLE
Update repeater element (enabled element nesting)

### DIFF
--- a/src/components/CRepeater/CRepeater.js
+++ b/src/components/CRepeater/CRepeater.js
@@ -12,24 +12,23 @@ export default {
   },
   methods: {
     getElementChildren(element, item) {
-      if (element) {
-        return map(element, (el) => {
-          const elDefinition = el;
-          if (!isNil(elDefinition.dataSource)) {
-            elDefinition.dataSource.items = [item];
-            elDefinition.dataSource.local = true;
-          }
-          return this.$createElement(this.getElementTag(el.type), {
-            props: {
-              definition: elDefinition,
-            },
+      if (!element) return null;
+
+      return map(element, (el) => {
+        const elDefinition = el;
+        if (!isNil(elDefinition.dataSource)) {
+          elDefinition.dataSource.items = [item];
+          elDefinition.dataSource.local = true;
+        }
+        return this.$createElement(this.getElementTag(el.type), {
+          props: {
+            definition: elDefinition,
           },
-            [
-              this.getElementChildren(elDefinition.elements, item),
-            ]);
-        });
-      }
-      return null;
+        },
+          [
+            this.getElementChildren(elDefinition.elements, item),
+          ]);
+      });
     },
     getRepeaterChildren(element, style) {
       if (isNil(this.config.dataSource) && isNil(this.items)) {

--- a/src/components/CRepeater/CRepeater.js
+++ b/src/components/CRepeater/CRepeater.js
@@ -1,13 +1,8 @@
-import { cloneDeep, isNil, map } from 'lodash';
+import { cloneDeep, each, isNil, map } from 'lodash';
 import Element from '../Element';
 
 export default {
   extends: Element,
-  computed: {
-    element() {
-      return this.config.elements[0];
-    },
-  },
   watch: {
     dataSource: {
       handler() {
@@ -15,7 +10,55 @@ export default {
       },
     },
   },
-  render(createElement) {
+  methods: {
+    getElementChildren(element, item) {
+      if (element) {
+        return map(element, (el) => {
+          const elDefinition = el;
+          if (!isNil(elDefinition.dataSource)) {
+            elDefinition.dataSource.items = [item];
+            elDefinition.dataSource.local = true;
+          }
+          return this.$createElement(this.getElementTag(el.type), {
+            props: {
+              definition: elDefinition,
+            },
+          });
+        });
+      }
+      return null;
+    },
+    getRepeaterChildren(element, style) {
+      if (isNil(this.config.dataSource) && isNil(this.items)) {
+        return this.$createElement(this.getElementTag(element.type), {
+          props: {
+            definition: element,
+          },
+        });
+      }
+      return map(this.items, (item, index) => {
+        const elementDefinition = cloneDeep(element);
+        if (!isNil(elementDefinition.dataSource)) {
+          elementDefinition.dataSource.items = [item];
+          elementDefinition.dataSource.local = true;
+        }
+
+        return this.$createElement(this.getElementTag(elementDefinition.type), {
+          props: {
+            definition: elementDefinition,
+          },
+          // Add parent static class so that it can inherit parent (container) style
+          staticClass: `${this.$options.namespace}${this.$parent.$attrs['data-type']}-item`,
+          style: this.registry.isPreviewMode && index >= 1 ? style : null,
+        },
+          [
+            this.getElementChildren(elementDefinition.elements, item),
+          ],
+        );
+      });
+    },
+  },
+  render() {
     const config = this.config;
     let children = [];
     const data = {
@@ -32,27 +75,19 @@ export default {
       userSelect: 'none',
     };
 
-    if (this.element && (isNil(this.element.dataSource) || isNil(this.items))) {
-      children = createElement(this.getElementTag(this.element.type), {
-        props: {
-          definition: this.element,
-        },
+    if (this.config.elements) {
+      each(this.config.elements, (el) => {
+        children.push(this.getRepeaterChildren(el, style));
       });
     } else {
-      children = map(this.items, (item, index) => {
-        const elementDefinition = cloneDeep(this.element);
-        elementDefinition.dataSource.items = [item];
-        elementDefinition.dataSource.local = true;
-
-        return createElement(this.getElementTag(this.element.type), {
-          props: {
-            definition: elementDefinition,
-          },
-          // Add parent static class so that it can inherit parent (container) style
-          staticClass: `${this.$options.namespace}${this.$parent.$attrs['data-type']}-item`,
-          style: this.registry.isPreviewMode && index >= 1 ? style : null,
-        });
-      });
+      // Render placeholder
+      children = this.$createElement(
+        'v-icon',
+        {
+          props: { xLarge: true },
+        },
+        'repeat',
+      );
     }
 
     return this.renderElement('v-card', data, children, true);

--- a/src/components/CRepeater/CRepeater.js
+++ b/src/components/CRepeater/CRepeater.js
@@ -75,7 +75,7 @@ export default {
       userSelect: 'none',
     };
 
-    if (this.config.elements) {
+    if (this.config.elements && this.config.elements.length) {
       each(this.config.elements, (el) => {
         children.push(this.getRepeaterChildren(el, style));
       });

--- a/src/components/CRepeater/CRepeater.js
+++ b/src/components/CRepeater/CRepeater.js
@@ -23,7 +23,10 @@ export default {
             props: {
               definition: elDefinition,
             },
-          });
+          },
+            [
+              this.getElementChildren(elDefinition.elements, item),
+            ]);
         });
       }
       return null;
@@ -42,7 +45,6 @@ export default {
           elementDefinition.dataSource.items = [item];
           elementDefinition.dataSource.local = true;
         }
-
         return this.$createElement(this.getElementTag(elementDefinition.type), {
           props: {
             definition: elementDefinition,


### PR DESCRIPTION
- Added repeater placeholder
- Enabled element nesting on repeater. I'm rendering and adding data source to children (with dataSource prop) of repeater element  
Example (this structure is now possible): 

![image](https://user-images.githubusercontent.com/6430146/53867196-9f13f980-3ff3-11e9-9d2a-e607eee32ff8.png)

Builder branch: feature/parentDataSource

resolves #175