### PR TITLE
 Increment Codebeat block nesting levels

### DIFF
--- a/.codebeatsettings
+++ b/.codebeatsettings
@@ -1,0 +1,5 @@
+{
+  "JAVASCRIPT": {
+    "BLOCK_NESTING": [4, 5, 6, 7]
+  }
+}


### PR DESCRIPTION
Customized Codebeat metric for block nesting levels, by incrementing default values. Vue component syntax adds some block levels by nature, so we have to be a bit more flexible here.

More info:
https://hub.codebeat.co/docs/metrics-customization
https://hub.codebeat.co/docs/software-quality-metrics#section-maximum-block-nesting